### PR TITLE
Fix README link path

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ JavaScript のライブラリは webpack でバンドル/minifyされます。
 バンドルするライブラリを変更する場合は、テンプレートごとに以下の bundle.js を修正し、リビルドしてください。
 - [html/template/admin/assets/js/bundle.js](html/template/admin/assets/js/bundle.js)
 - [html/template/default/assets/js/bundle.js](html/template/default/assets/js/bundle.js)
-- [html/template/install/assets/js/bundle.js](html/template/default/install/js/bundle.js)
+- [html/template/install/assets/js/bundle.js](html/template/install/assets/js/bundle.js)
 
 ```shell
 npm ci # 初回およびpackage-lock.jsonに変更があったとき


### PR DESCRIPTION
## Summary
- fix broken link for install template's bundle.js in README

## Testing
- `bin/phpunit --version` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_684910b08254832893a72774a3c9dd0c