### PR TITLE
fix(CI/CD): Dockerbuild が失敗していたため修正

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,6 +4,8 @@ use Eccube\Kernel;
 use Eccube\Service\SystemService;
 use Symfony\Component\ErrorHandler\Debug;
 use Dotenv\Dotenv;
+use Dotenv\Repository\Adapter\PutenvAdapter;
+use Dotenv\Repository\RepositoryBuilder;
 use Symfony\Component\HttpFoundation\Request;
 
 // システム要件チェック
@@ -37,7 +39,17 @@ if (!isset($_SERVER['APP_ENV'])) {
     // APP_ENV が環境変数として設定されている場合（Docker など）でも .env を読み込む。
     // ただし既存の環境変数（Docker で設定済みのもの）は上書きしない。
     // これにより管理画面からのテンプレート切り替えが .env への書き込みで反映される。
-    (Dotenv::createImmutable(__DIR__))->safeLoad();
+    //
+    // 既定の createImmutable は $_ENV / $_SERVER / Apache CGI でのみ既存値を判定し、
+    // putenv 経由の値は見ない。Apache の PassEnv で渡されない変数 (DATABASE_URL 等) や
+    // PHP の variables_order に E が含まれない構成では、本来 Docker から渡された env が
+    // 「未設定」と誤判定され、.env の値で $_SERVER 等を上書きしてしまう。
+    // PutenvAdapter を明示的に追加することで getenv 側の既存値も尊重する。
+    $repository = RepositoryBuilder::createWithDefaultAdapters()
+        ->addAdapter(PutenvAdapter::class)
+        ->immutable()
+        ->make();
+    Dotenv::create($repository, __DIR__)->safeLoad();
 }
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 


### PR DESCRIPTION
admin01 が CI で 500 エラーになるが, 既存の `Upload logs (path: var/log/)` は ホスト側の空ディレクトリを upload しており, コンテナ内 Symfony の例外 trace を 取り出せていなかった. 失敗時にコンテナから var/log と .env, env vars, docker compose logs を回収する step を追加する.

- Dump container logs step で `docker compose cp ec-cube:/var/www/html/var/log` と env 関連の dump を `container-logs/` に集める
- evidence と logs の artifact 名にマトリクスの PHP バージョンを付与し, 3 ジョブ間で衝突しないようにする
- Upload logs (host) は空のことが多いため `if-no-files-found: ignore`
- Upload container logs ステップを新設


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 環境変数の読み込み動作を改善しました。コンテナやDocker経由で設定された既存の環境値が設定ファイルによって上書きされることなく、適切に優先されるようになります。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dotani1111/ec-cube/pull/33)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->