### PR TITLE
[CI検証用] ci: CI のデータベースバージョンを 4.4 システム要件に合わせる

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,10 +18,10 @@ jobs:
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
-            database_server_version: 14
+            database_server_version: 18
     services:
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -96,7 +96,7 @@ jobs:
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
-            database_server_version: 14
+            database_server_version: 18
           - group: admin01
             app_env: 'codeception'
           - group: admin02
@@ -109,7 +109,7 @@ jobs:
             app_env: 'install'
     services:
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/.github/workflows/deny-test.yml
+++ b/.github/workflows/deny-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     services:
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -43,7 +43,7 @@ jobs:
         env:
           APP_ENV: 'prod'
           DATABASE_URL: postgres://postgres:password@127.0.0.1:5432/eccube_db
-          DATABASE_SERVER_VERSION: 14
+          DATABASE_SERVER_VERSION: 18
         run: |
           rm -rf $GITHUB_WORKSPACE/app/Plugin/*
           echo "APP_ENV=${APP_ENV}" > .env
@@ -55,7 +55,7 @@ jobs:
 #        env:
 #          APP_ENV: 'prod'
 #          DATABASE_URL: postgres://postgres:password@127.0.0.1:5432/eccube_db
-#          DATABASE_SERVER_VERSION: 14
+#          DATABASE_SERVER_VERSION: 18
 #        run: |
 #           bin/console eccube:composer:require "ec-cube/recommend42"
 #           bin/console eccube:composer:require "ec-cube/coupon42"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     services:
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -45,7 +45,7 @@ jobs:
         env:
           APP_ENV: 'prod'
           DATABASE_URL: postgres://postgres:password@127.0.0.1:5432/eccube_db
-          DATABASE_SERVER_VERSION: 14
+          DATABASE_SERVER_VERSION: 18
         run: |
           rm -rf $GITHUB_WORKSPACE/app/Plugin/*
           echo "APP_ENV=${APP_ENV}" > .env
@@ -57,7 +57,7 @@ jobs:
         env:
           APP_ENV: 'prod'
           DATABASE_URL: postgres://postgres:password@127.0.0.1:5432/eccube_db
-          DATABASE_SERVER_VERSION: 14
+          DATABASE_SERVER_VERSION: 18
         run: |
            bin/console eccube:composer:require "ec-cube/recommend42"
            bin/console eccube:composer:require "ec-cube/coupon42"

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - db: pgsql
             database_url: postgres://dbuser:secret@127.0.0.1:15432/eccubedb
-            database_server_version: 14
+            database_server_version: 18
           - php: '8.3'
             tag: '8.3-apache'
             ext_install_args: 'zip gd mysqli pdo_mysql opcache intl'

--- a/.github/workflows/e2e-test-throttling.yml
+++ b/.github/workflows/e2e-test-throttling.yml
@@ -32,10 +32,10 @@ jobs:
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
-            database_server_version: 14
+            database_server_version: 18
     services:
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -33,10 +33,10 @@ jobs:
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
-            database_server_version: 14
+            database_server_version: 18
     services:
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -29,11 +29,11 @@ jobs:
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
-            database_server_version: 14
+            database_server_version: 18
             database_charset: utf8
           - db: mysql
             database_url: mysql://root:password@127.0.0.1:3306/eccube_db
-            database_server_version: 5
+            database_server_version: 8
             database_charset: utf8mb4
 
     services:
@@ -45,7 +45,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -180,11 +180,11 @@ jobs:
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
-            database_server_version: 14
+            database_server_version: 18
             database_charset: utf8
           - db: mysql
             database_url: mysql://root:password@127.0.0.1:3306/eccube_db
-            database_server_version: 5
+            database_server_version: 8
             database_charset: utf8mb4
 
     services:
@@ -196,7 +196,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -330,11 +330,11 @@ jobs:
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
-            database_server_version: 14
+            database_server_version: 18
             database_charset: utf8
           - db: mysql
             database_url: mysql://root:password@127.0.0.1:3306/eccube_db
-            database_server_version: 5
+            database_server_version: 8
             database_charset: utf8mb4
 
     services:
@@ -346,7 +346,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -480,11 +480,11 @@ jobs:
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
-            database_server_version: 14
+            database_server_version: 18
             database_charset: utf8
           - db: mysql
             database_url: mysql://root:password@127.0.0.1:3306/eccube_db
-            database_server_version: 5
+            database_server_version: 8
             database_charset: utf8mb4
         exclude:
           - db: mysql
@@ -499,7 +499,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -626,11 +626,11 @@ jobs:
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
-            database_server_version: 14
+            database_server_version: 18
             database_charset: utf8
           - db: mysql
             database_url: mysql://root:password@127.0.0.1:3306/eccube_db
-            database_server_version: 5
+            database_server_version: 8
             database_charset: utf8mb4
 
     services:
@@ -642,7 +642,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -767,11 +767,11 @@ jobs:
         include:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
-            database_server_version: 14
+            database_server_version: 18
             database_charset: utf8
           - db: mysql
             database_url: mysql://root:password@127.0.0.1:3306/eccube_db
-            database_server_version: 5
+            database_server_version: 8
             database_charset: utf8mb4
 
     services:
@@ -783,7 +783,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         operating-system: [ ubuntu-24.04 ]
         php: [ '8.2', '8.3', '8.4', '8.5' ]
-        db: [ mysql, pgsql, sqlite3 ]
+        db: [ mysql, pgsql, pgsql13, sqlite3 ]
         include:
           - db: mysql
             database_url: mysql://root:password@127.0.0.1:3306/eccube_db
@@ -23,8 +23,15 @@ jobs:
             database_charset: utf8mb4
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
-            database_server_version: 16
+            database_server_version: 18
             database_charset: utf8
+            postgres_version: 18
+          # サポート最小バージョンの PostgreSQL でも検証する
+          - db: pgsql13
+            database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
+            database_server_version: 13
+            database_charset: utf8
+            postgres_version: 13
           - db: sqlite3
             database_url: sqlite:///var/eccube.db
             database_server_version: 3
@@ -39,7 +46,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       postgres:
-        image: postgres:16
+        image: postgres:${{ matrix.postgres_version || 18 }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -113,7 +120,7 @@ jobs:
           php -c php.ini vendor/bin/phpunit --group cache-clear
           php -c php.ini vendor/bin/phpunit --group cache-clear-install
       - name: PHPUnit (update-schema-doctrine)
-        if: matrix.db == 'pgsql'
+        if: startsWith(matrix.db, 'pgsql')
         env:
           APP_ENV: 'test'
           DATABASE_URL: ${{ matrix.database_url }}

--- a/.github/workflows/vaddy-1.yml
+++ b/.github/workflows/vaddy-1.yml
@@ -24,7 +24,7 @@ jobs:
             command1: '-x admin -x plugin'
     services:
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -78,7 +78,7 @@ jobs:
       - name: "EC-CUBE: setup"
         env:
           DATABASE_URL: postgres://postgres:password@127.0.0.1:5432/eccube_db
-          DATABASE_SERVER_VERSION: 14
+          DATABASE_SERVER_VERSION: 18
         run: |
           php bin/template_jp.php
           rm -rf app/Plugin/*
@@ -109,7 +109,7 @@ jobs:
         env:
           APP_ENV: 'prod'
           DATABASE_URL: postgres://postgres:password@127.0.0.1:5432/eccube_db
-          DATABASE_SERVER_VERSION: 14
+          DATABASE_SERVER_VERSION: 18
         run: |
           bin/console eccube:composer:require "ec-cube/recommend4"
           bin/console eccube:composer:require "ec-cube/coupon4"
@@ -125,7 +125,7 @@ jobs:
       - name: Pre Install Plugins
         env:
           DATABASE_URL: postgres://postgres:password@127.0.0.1:5432/eccube_db
-          DATABASE_SERVER_VERSION: 14
+          DATABASE_SERVER_VERSION: 18
           PGPASSWORD: 'password'
         run: |
           psql eccube_db -h 127.0.0.1 -U postgres -c "select id,name,code,0 as enabled,version,source,0 as initialized,'2021-08-13 00:00:00' as create_date,'2021-08-13 00:00:00' as update_date,discriminator_type from dtb_plugin;" -A -F, --pset footer > src/Eccube/Resource/doctrine/import_csv/ja/dtb_plugin.csv
@@ -172,7 +172,7 @@ jobs:
             -e APP_ENV=dev \
             -e APP_DEBUG=1 \
             -e DATABASE_URL="postgres://postgres:password@172.17.0.1:5432/eccube_db" \
-            -e DATABASE_SERVER_VERSION=14 \
+            -e DATABASE_SERVER_VERSION=18 \
             -e MAILER_URL="smtp://172.17.0.1:1025" \
             -v ${PWD}/html:/tmp/html \
             --rm -d -p 8080:80 --name eccube ec-cube
@@ -191,7 +191,7 @@ jobs:
         env:
           APP_ENV: "codeception"
           DATABASE_URL: "postgres://postgres:password@127.0.0.1:5432/eccube_db"
-          DATABASE_SERVER_VERSION: "14"
+          DATABASE_SERVER_VERSION: "18"
           MAILER_URL: "smtp://127.0.0.1:1025"
           BASE_URL: "http://${{ secrets[format('{0}{1}', 'VADDY_FQDN_', matrix.vaddy_project)] }}:8080"
           VADDY_PROXY: "${{ secrets.VADDY_PROXY }}"
@@ -237,7 +237,7 @@ jobs:
             -e APP_ENV=dev \
             -e APP_DEBUG=1 \
             -e DATABASE_URL="postgres://postgres:password@172.17.0.1:5432/eccube_db" \
-            -e DATABASE_SERVER_VERSION=14 \
+            -e DATABASE_SERVER_VERSION=18 \
             -e MAILER_URL="smtp://172.17.0.1:1025" \
             -v ${PWD}/html:/tmp/html \
             --rm -d -p 8080:80 --name eccube ec-cube
@@ -258,7 +258,7 @@ jobs:
         env:
           APP_ENV: "codeception"
           DATABASE_URL: "postgres://postgres:password@127.0.0.1:5432/eccube_db"
-          DATABASE_SERVER_VERSION: "14"
+          DATABASE_SERVER_VERSION: "18"
           MAILER_URL: "smtp://127.0.0.1:1025"
           BASE_URL: "http://${{ secrets[format('{0}{1}', 'VADDY_FQDN_', matrix.vaddy_project)] }}:8080"
           VADDY_PROXY: "${{ secrets.VADDY_PROXY }}"
@@ -306,7 +306,7 @@ jobs:
             -e APP_ENV=dev \
             -e APP_DEBUG=1 \
             -e DATABASE_URL="postgres://postgres:password@172.17.0.1:5432/eccube_db" \
-            -e DATABASE_SERVER_VERSION=14 \
+            -e DATABASE_SERVER_VERSION=18 \
             -e MAILER_URL="smtp://172.17.0.1:1025" \
             -v ${PWD}/html:/tmp/html \
             --rm -d -p 8080:80 --name eccube ec-cube
@@ -327,7 +327,7 @@ jobs:
         env:
           APP_ENV: "codeception"
           DATABASE_URL: "postgres://postgres:password@127.0.0.1:5432/eccube_db"
-          DATABASE_SERVER_VERSION: "14"
+          DATABASE_SERVER_VERSION: "18"
           MAILER_URL: "smtp://127.0.0.1:1025"
           BASE_URL: "http://${{ secrets[format('{0}{1}', 'VADDY_FQDN_', matrix.vaddy_project)] }}:8080"
           VADDY_PROXY: "${{ secrets.VADDY_PROXY }}"
@@ -375,7 +375,7 @@ jobs:
             -e APP_ENV=dev \
             -e APP_DEBUG=1 \
             -e DATABASE_URL="postgres://postgres:password@172.17.0.1:5432/eccube_db" \
-            -e DATABASE_SERVER_VERSION=14 \
+            -e DATABASE_SERVER_VERSION=18 \
             -e MAILER_URL="smtp://172.17.0.1:1025" \
             -v ${PWD}/html:/tmp/html \
             --rm -d -p 8080:80 --name eccube ec-cube
@@ -396,7 +396,7 @@ jobs:
         env:
           APP_ENV: "codeception"
           DATABASE_URL: "postgres://postgres:password@127.0.0.1:5432/eccube_db"
-          DATABASE_SERVER_VERSION: "14"
+          DATABASE_SERVER_VERSION: "18"
           MAILER_URL: "smtp://127.0.0.1:1025"
           BASE_URL: "http://${{ secrets[format('{0}{1}', 'VADDY_FQDN_', matrix.vaddy_project)] }}:8080"
           VADDY_PROXY: "${{ secrets.VADDY_PROXY }}"
@@ -444,7 +444,7 @@ jobs:
             -e APP_ENV=dev \
             -e APP_DEBUG=1 \
             -e DATABASE_URL="postgres://postgres:password@172.17.0.1:5432/eccube_db" \
-            -e DATABASE_SERVER_VERSION=14 \
+            -e DATABASE_SERVER_VERSION=18 \
             -e MAILER_URL="smtp://172.17.0.1:1025" \
             -v ${PWD}/html:/tmp/html \
             --rm -d -p 8080:80 --name eccube ec-cube
@@ -465,7 +465,7 @@ jobs:
         env:
           APP_ENV: "codeception"
           DATABASE_URL: "postgres://postgres:password@127.0.0.1:5432/eccube_db"
-          DATABASE_SERVER_VERSION: "14"
+          DATABASE_SERVER_VERSION: "18"
           MAILER_URL: "smtp://127.0.0.1:1025"
           BASE_URL: "http://${{ secrets[format('{0}{1}', 'VADDY_FQDN_', matrix.vaddy_project)] }}:8080"
           VADDY_PROXY: "${{ secrets.VADDY_PROXY }}"

--- a/.github/workflows/vaddy-2.yml
+++ b/.github/workflows/vaddy-2.yml
@@ -25,7 +25,7 @@ jobs:
             command1: '-x admin -x front'
     services:
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -79,7 +79,7 @@ jobs:
       - name: "EC-CUBE: setup"
         env:
           DATABASE_URL: postgres://postgres:password@127.0.0.1:5432/eccube_db
-          DATABASE_SERVER_VERSION: 14
+          DATABASE_SERVER_VERSION: 18
         run: |
           php bin/template_jp.php
           rm -rf app/Plugin/*
@@ -110,7 +110,7 @@ jobs:
         env:
           APP_ENV: 'prod'
           DATABASE_URL: postgres://postgres:password@127.0.0.1:5432/eccube_db
-          DATABASE_SERVER_VERSION: 14
+          DATABASE_SERVER_VERSION: 18
         run: |
           bin/console eccube:composer:require "ec-cube/recommend4"
           bin/console eccube:composer:require "ec-cube/coupon4"
@@ -126,7 +126,7 @@ jobs:
       - name: Pre Install Plugins
         env:
           DATABASE_URL: postgres://postgres:password@127.0.0.1:5432/eccube_db
-          DATABASE_SERVER_VERSION: 14
+          DATABASE_SERVER_VERSION: 18
           PGPASSWORD: 'password'
         run: |
           psql eccube_db -h 127.0.0.1 -U postgres -c "select id,name,code,0 as enabled,version,source,0 as initialized,'2021-08-13 00:00:00' as create_date,'2021-08-13 00:00:00' as update_date,discriminator_type from dtb_plugin;" -A -F, --pset footer > src/Eccube/Resource/doctrine/import_csv/ja/dtb_plugin.csv
@@ -173,7 +173,7 @@ jobs:
             -e APP_ENV=dev \
             -e APP_DEBUG=1 \
             -e DATABASE_URL="postgres://postgres:password@172.17.0.1:5432/eccube_db" \
-            -e DATABASE_SERVER_VERSION=14 \
+            -e DATABASE_SERVER_VERSION=18 \
             -e MAILER_URL="smtp://172.17.0.1:1025" \
             -v ${PWD}/html:/tmp/html \
             --rm -d -p 8080:80 --name eccube ec-cube
@@ -192,7 +192,7 @@ jobs:
         env:
           APP_ENV: "codeception"
           DATABASE_URL: "postgres://postgres:password@127.0.0.1:5432/eccube_db"
-          DATABASE_SERVER_VERSION: "14"
+          DATABASE_SERVER_VERSION: "18"
           MAILER_URL: "smtp://127.0.0.1:1025"
           BASE_URL: "http://${{ secrets[format('{0}{1}', 'VADDY_FQDN_', matrix.vaddy_project)] }}:8080"
           VADDY_PROXY: "${{ secrets.VADDY_PROXY }}"
@@ -238,7 +238,7 @@ jobs:
             -e APP_ENV=dev \
             -e APP_DEBUG=1 \
             -e DATABASE_URL="postgres://postgres:password@172.17.0.1:5432/eccube_db" \
-            -e DATABASE_SERVER_VERSION=14 \
+            -e DATABASE_SERVER_VERSION=18 \
             -e MAILER_URL="smtp://172.17.0.1:1025" \
             -v ${PWD}/html:/tmp/html \
             --rm -d -p 8080:80 --name eccube ec-cube
@@ -259,7 +259,7 @@ jobs:
         env:
           APP_ENV: "codeception"
           DATABASE_URL: "postgres://postgres:password@127.0.0.1:5432/eccube_db"
-          DATABASE_SERVER_VERSION: "14"
+          DATABASE_SERVER_VERSION: "18"
           MAILER_URL: "smtp://127.0.0.1:1025"
           BASE_URL: "http://${{ secrets[format('{0}{1}', 'VADDY_FQDN_', matrix.vaddy_project)] }}:8080"
           VADDY_PROXY: "${{ secrets.VADDY_PROXY }}"
@@ -307,7 +307,7 @@ jobs:
             -e APP_ENV=dev \
             -e APP_DEBUG=1 \
             -e DATABASE_URL="postgres://postgres:password@172.17.0.1:5432/eccube_db" \
-            -e DATABASE_SERVER_VERSION=14 \
+            -e DATABASE_SERVER_VERSION=18 \
             -e MAILER_URL="smtp://172.17.0.1:1025" \
             -v ${PWD}/html:/tmp/html \
             --rm -d -p 8080:80 --name eccube ec-cube
@@ -328,7 +328,7 @@ jobs:
         env:
           APP_ENV: "codeception"
           DATABASE_URL: "postgres://postgres:password@127.0.0.1:5432/eccube_db"
-          DATABASE_SERVER_VERSION: "14"
+          DATABASE_SERVER_VERSION: "18"
           MAILER_URL: "smtp://127.0.0.1:1025"
           BASE_URL: "http://${{ secrets[format('{0}{1}', 'VADDY_FQDN_', matrix.vaddy_project)] }}:8080"
           VADDY_PROXY: "${{ secrets.VADDY_PROXY }}"
@@ -376,7 +376,7 @@ jobs:
             -e APP_ENV=dev \
             -e APP_DEBUG=1 \
             -e DATABASE_URL="postgres://postgres:password@172.17.0.1:5432/eccube_db" \
-            -e DATABASE_SERVER_VERSION=14 \
+            -e DATABASE_SERVER_VERSION=18 \
             -e MAILER_URL="smtp://172.17.0.1:1025" \
             -v ${PWD}/html:/tmp/html \
             --rm -d -p 8080:80 --name eccube ec-cube
@@ -397,7 +397,7 @@ jobs:
         env:
           APP_ENV: "codeception"
           DATABASE_URL: "postgres://postgres:password@127.0.0.1:5432/eccube_db"
-          DATABASE_SERVER_VERSION: "14"
+          DATABASE_SERVER_VERSION: "18"
           MAILER_URL: "smtp://127.0.0.1:1025"
           BASE_URL: "http://${{ secrets[format('{0}{1}', 'VADDY_FQDN_', matrix.vaddy_project)] }}:8080"
           VADDY_PROXY: "${{ secrets.VADDY_PROXY }}"
@@ -445,7 +445,7 @@ jobs:
             -e APP_ENV=dev \
             -e APP_DEBUG=1 \
             -e DATABASE_URL="postgres://postgres:password@172.17.0.1:5432/eccube_db" \
-            -e DATABASE_SERVER_VERSION=14 \
+            -e DATABASE_SERVER_VERSION=18 \
             -e MAILER_URL="smtp://172.17.0.1:1025" \
             -v ${PWD}/html:/tmp/html \
             --rm -d -p 8080:80 --name eccube ec-cube
@@ -466,7 +466,7 @@ jobs:
         env:
           APP_ENV: "codeception"
           DATABASE_URL: "postgres://postgres:password@127.0.0.1:5432/eccube_db"
-          DATABASE_SERVER_VERSION: "14"
+          DATABASE_SERVER_VERSION: "18"
           MAILER_URL: "smtp://127.0.0.1:1025"
           BASE_URL: "http://${{ secrets[format('{0}{1}', 'VADDY_FQDN_', matrix.vaddy_project)] }}:8080"
           VADDY_PROXY: "${{ secrets.VADDY_PROXY }}"

--- a/.github/workflows/vaddy/prepare/action.yml
+++ b/.github/workflows/vaddy/prepare/action.yml
@@ -73,7 +73,7 @@ runs:
       shell: bash
       env:
         DATABASE_URL: postgres://postgres:password@127.0.0.1:5432/eccube_db
-        DATABASE_SERVER_VERSION: 14
+        DATABASE_SERVER_VERSION: 18
       run: |
         composer install --no-scripts --no-dev --no-interaction --optimize-autoloader --no-plugins
         php bin/template_jp.php
@@ -113,7 +113,7 @@ runs:
       env:
         APP_ENV: 'prod'
         DATABASE_URL: postgres://postgres:password@127.0.0.1:5432/eccube_db
-        DATABASE_SERVER_VERSION: 14
+        DATABASE_SERVER_VERSION: 18
         PGPASSWORD: 'password'
       run: |
         bin/console eccube:composer:require "ec-cube/recommend42"

--- a/.github/workflows/vaddy/scan/action.yml
+++ b/.github/workflows/vaddy/scan/action.yml
@@ -33,7 +33,7 @@ runs:
           -e APP_ENV=prod \
           -e APP_DEBUG=0 \
           -e DATABASE_URL="postgres://postgres:password@172.17.0.1:5432/eccube_db" \
-          -e DATABASE_SERVER_VERSION=14 \
+          -e DATABASE_SERVER_VERSION=18 \
           -e MAILER_URL="smtp://172.17.0.1:1025" \
           -v ${PWD}/html:/tmp/html \
           --rm -d -p 8080:80 --name eccube ec-cube
@@ -58,7 +58,7 @@ runs:
       env:
         APP_ENV: "codeception"
         DATABASE_URL: "postgres://postgres:password@127.0.0.1:5432/eccube_db"
-        DATABASE_SERVER_VERSION: "14"
+        DATABASE_SERVER_VERSION: "18"
         MAILER_URL: "smtp://127.0.0.1:1025"
         BASE_URL: "http://${{ inputs.vaddy-fqdn }}:8080"
         VADDY_PROXY: "${{ inputs.vaddy-proxy }}"

--- a/.github/workflows/vaddyscan.yml
+++ b/.github/workflows/vaddyscan.yml
@@ -75,7 +75,7 @@ jobs:
 #            command6: 'EF06OtherCest:other_お問い合わせ1'
     services:
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -11,14 +11,17 @@ services:
         condition: service_healthy
     environment:
       DATABASE_URL: "postgres://dbuser:secret@postgres/eccubedb"
-      DATABASE_SERVER_VERSION: 14
+      DATABASE_SERVER_VERSION: 18
       DATABASE_CHARSET: 'utf8'
 
   postgres:
-    image: postgres:14
+    image: postgres:18
     environment:
       POSTGRES_USER: dbuser
       POSTGRES_PASSWORD: secret
+      # postgres:18 で PGDATA のデフォルトレイアウトが変わり、従来の volume
+      # マウント先 (/var/lib/postgresql/data) だけでは起動に失敗するため明示する
+      PGDATA: /var/lib/postgresql/data
     ports:
       - 15432:5432
     volumes:


### PR DESCRIPTION
本家へ PR を出す前の CI 検証用ドラフト PR。マージしない。

検証ポイント:
- unit-test の pgsql13 レグ（PostgreSQL 13）が通るか
- postgres:18 起動（dockerbuild / 各WF）
- MySQL server_version 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)