### PR TITLE
test(e2e): admin-basicinfo の flake を堅牢化（カート投入待機＋支払一覧描画ゲート）

### DIFF
--- a/e2e/tests/admin-basicinfo.spec.ts
+++ b/e2e/tests/admin-basicinfo.spec.ts
@@ -71,6 +71,15 @@ test.describe('Admin Basic Info (EA07)', () => {
     // --- CREATE ---
     await page.goto(`/${adminRoute}/setting/shop/payment`);
     await page.waitForLoadState('load');
+    // 別コンテキストの front 操作で admin セッションが無効化されることがあるため、
+    // 再ログイン→未遷移なら payment へ再 goto し、一覧描画(.c-pageTitle)を待ってから
+    // 件数取得・新規作成ボタンを押す（btn-ec-regular 不在による click timeout 回避）。
+    await ensureAdminLoggedIn(page);
+    if (!page.url().includes('/payment')) {
+      await page.goto(`/${adminRoute}/setting/shop/payment`);
+      await page.waitForLoadState('load');
+    }
+    await expect(page.locator('.c-pageTitle')).toContainText('支払方法一覧');
     const beforeCount = await page.locator('.c-contentsArea__primaryCol li.sortable-item').count();
 
     await page.locator('.c-contentsArea__primaryCol .btn-ec-regular').click();
@@ -87,6 +96,7 @@ test.describe('Admin Basic Info (EA07)', () => {
     // Verify on list
     await page.goto(`/${adminRoute}/setting/shop/payment`);
     await page.waitForLoadState('load');
+    await expect(page.locator('.c-pageTitle')).toContainText('支払方法一覧');
     const afterCreateCount = await page.locator('.c-contentsArea__primaryCol li.sortable-item').count();
     expect(afterCreateCount).toBe(beforeCount + 1);
     // New payment appears first (nth-child(2) because list has a header item)
@@ -105,6 +115,7 @@ test.describe('Admin Basic Info (EA07)', () => {
 
     await page.goto(`/${adminRoute}/setting/shop/payment`);
     await page.waitForLoadState('load');
+    await expect(page.locator('.c-pageTitle')).toContainText('支払方法一覧');
     await expect(page.locator('.c-contentsArea__primaryCol .c-primaryCol .card-body ul li:nth-child(2)')).toContainText(paymentNameEdited);
 
     // --- DELETE ---
@@ -119,6 +130,7 @@ test.describe('Admin Basic Info (EA07)', () => {
     // Verify count is back to original
     await page.goto(`/${adminRoute}/setting/shop/payment`);
     await page.waitForLoadState('load');
+    await expect(page.locator('.c-pageTitle')).toContainText('支払方法一覧');
     const afterDeleteCount = await page.locator('.c-contentsArea__primaryCol li.sortable-item').count();
     expect(afterDeleteCount).toBe(beforeCount);
   });
@@ -570,7 +582,10 @@ test.describe('Admin Basic Info (EA07)', () => {
 
     // Select quantity if needed, then add to cart
     await frontPage.locator('.ec-productRole__btn button[type="submit"]').first().click();
-    await frontPage.waitForLoadState('load');
+    // カート投入は product_add_cart への AJAX で画面遷移しないため、waitForLoadState('load') は
+    // 即時 resolve してしまう。成功モーダル表示でカート反映完了を待つ。
+    await expect(frontPage.locator('div.ec-modal-box')).toBeVisible({ timeout: 10_000 });
+    await expect(frontPage.locator('#ec-modal-header')).toContainText('カートに追加しました');
 
     // Go to cart and proceed to checkout
     await frontPage.goto('/cart');
@@ -650,7 +665,10 @@ test.describe('Admin Basic Info (EA07)', () => {
     await frontPage.goto('/products/detail/2');
     await frontPage.waitForLoadState('load');
     await frontPage.locator('.ec-productRole__btn button[type="submit"]').first().click();
-    await frontPage.waitForLoadState('load');
+    // カート投入は product_add_cart への AJAX で画面遷移しないため、waitForLoadState('load') は
+    // 即時 resolve してしまう。成功モーダル表示でカート反映完了を待つ。
+    await expect(frontPage.locator('div.ec-modal-box')).toBeVisible({ timeout: 10_000 });
+    await expect(frontPage.locator('#ec-modal-header')).toContainText('カートに追加しました');
 
     // Go to cart -> checkout
     await frontPage.goto('/cart');


### PR DESCRIPTION
## 概要
admin-basicinfo e2e の間欠 flake 2 系統を、一次証拠に基づき堅牢化。

## 修正
### M1: ポイント設定 有効/無効 (EA0701-UC01-T16/T17)
- add-to-cart は `product_add_cart` への **AJAX**(`detail.twig` L209)で、成功時に `.ec-modal` を表示するだけで**画面遷移しない**。
- `waitForLoadState('load')` は AJAX に無効で即時 resolve → カート反映前に `/cart` 遷移 → `レジに進む` 不在で `locator.click` 30s タイムアウト。
- → リポジトリ標準パターン（`front-order.spec.ts` 等）に合わせ、成功モーダル `div.ec-modal-box` の表示＋`#ec-modal-header` のテキスト('カートに追加しました')を待つ。

### M3: 支払方法CRUD (EA0705)
- `payment_crud` の一覧操作が、堅牢な `payment_list` と違いセッション再ログイン/一覧描画待ちなしで件数取得→`btn-ec-regular` click していた → 要素不在で click timeout。
- → `payment_list` と同じく `ensureAdminLoggedIn` ＋ `.c-pageTitle`='支払方法一覧' のゲートを CREATE と一覧再取得（CREATE後/EDIT後/DELETE後）の各所に追加。

## 検証
- M1 の修正方針は admin-basicinfo を 10 並列×複数回まわし再発ゼロを確認済み（検証用 workflow は確認後に削除）。
- レビュー: silent-failure-hunter / pr-test-analyzer により「待機・フォールバックが実バグを隠さない」「検証意図を弱めない」ことを確認し、指摘（標準パターン化・ゲートの網羅・コメント補強）を反映済み。