### PR TITLE
ci(e2e): mailcatcher コンテナを mailpit に置換 (Docker Hub pull 回避)

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,12 +37,6 @@ jobs:
           - db: pgsql
             database_url: postgres://postgres:password@127.0.0.1:5432/eccube_db
             database_server_version: 18
-    services:
-      mailcatcher:
-        image: schickling/mailcatcher
-        ports:
-          - 1080:1080
-          - 1025:1025
 
     steps:
       - name: Checkout
@@ -153,6 +147,21 @@ jobs:
         with:
           packages: fonts-ipafont fonts-ipaexfont
           version: 1.0
+
+      - name: Start Mailpit (SMTP sink)
+        # mailcatcher コンテナ(Docker Hub pull)の置き換え。mailpit の Go 単一バイナリを
+        # GitHub Releases から gh(GITHUB_TOKEN 認証)で取得し、SHA256 をハードコード検証する。
+        # タグは可変なので、信頼値を自リポジトリに焼き込む＝action の @<commit-sha> ピン相当。
+        # CDN 配信なので registry の pull レート制限にも乗らない。1025 で SMTP を受ける
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAILPIT_VERSION: v1.30.3
+          MAILPIT_SHA256: 6c7af993fb4054def4adfc7c85b40f9570fd6172eaccd0221c4969f2cc7a6294
+        run: |
+          gh release download "$MAILPIT_VERSION" --repo axllent/mailpit --pattern 'mailpit-linux-amd64.tar.gz' --dir "$RUNNER_TEMP"
+          echo "${MAILPIT_SHA256}  ${RUNNER_TEMP}/mailpit-linux-amd64.tar.gz" | sha256sum -c -
+          tar -xzf "$RUNNER_TEMP/mailpit-linux-amd64.tar.gz" -C "$RUNNER_TEMP"
+          "$RUNNER_TEMP/mailpit" --smtp 127.0.0.1:1025 --listen 127.0.0.1:8025 &
 
       - name: Start PHP Development Server
         env:


### PR DESCRIPTION
Issue #6879 の結論(mailpit 移行)を e2e-test.yml で先行実装し、CI で実証する。

- `services:` の `schickling/mailcatcher`(Docker Hub pull で不安定)を撤去
- mailpit(Go 単一バイナリ・GitHub Releases)を取得して 1025 で SMTP 受信。MAILER_DSN は据え置き
- e2e はメール本文を読まないので受信して破棄で十分(将来 API 8025 で読取に拡張可)

## 検証
このブランチで e2e-test.yml が green（特に front-customer 登録 / front-other パスワード再発行のメール送信フロー）を確認 → 通れば e2e-test-throttling.yml / plugin-test.yml に展開。

## 未確定(要フォロー)
mailpit の取得を install.sh(develop) にしている。マージ前にバージョン固定へ。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * E2Eテスト環境のメール受信基盤を更新し、Mailpit を用いた安定した動作を提供します。
  * 受信の待受設定を見直し、SMTP は `127.0.0.1:1025`、Web は `127.0.0.1:8025` で待ち受けるよう改善しました。
  * 従来どおり PHP 開発サーバーでは `MAILER_DSN: smtp://127.0.0.1:1025` を利用します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->