### PR TITLE
feat(mcp-cli): MCP ツールを bin/console から実行する CLI を追加

### DIFF
--- a/src/Eccube/Command/McpCallCommand.php
+++ b/src/Eccube/Command/McpCallCommand.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command;
+
+use Eccube\DependencyInjection\Compiler\McpScopeEnforcementPass;
+use Mcp\Capability\Registry\ReferenceHandlerInterface;
+use Mcp\Capability\RegistryInterface;
+use Mcp\Exception\ToolNotFoundException;
+use Mcp\Server\Builder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * MCP ツールを CLI から実行する (MCP の `tools/call` 相当)。
+ *
+ * コンソール AI クライアント (Claude Code 等) が、 コンテキストを食う MCP サーバ接続なしに、
+ * CLI から同じ操作を行うための実行口。 ツール名・引数は `eccube:mcp:tools` のスキーマに従う。
+ *
+ * 認証・scope 強制は通さない (scope 強制なしの inner ReferenceHandler を使う)。 本コマンドを
+ * 実行できる = サーバ/DB にアクセスできる前提であり、 HTTP の OAuth Bearer + scope とは別の
+ * 「ローカル信頼」で運用する。
+ */
+#[AsCommand(
+    name: 'eccube:mcp:call',
+    description: 'MCP ツールを CLI から実行し結果を JSON で出力する (tools/call 相当・ローカル信頼・トークン不要)',
+)]
+final class McpCallCommand extends Command
+{
+    public function __construct(
+        #[Autowire(service: 'mcp.registry')]
+        private readonly RegistryInterface $registry,
+        // scope 強制を通さない本物の Tool 実行器。 CLI はローカル信頼なので scope 検査を挟まない。
+        #[Autowire(service: McpScopeEnforcementPass::INNER_REFERENCE_HANDLER_ID)]
+        private readonly ReferenceHandlerInterface $handler,
+        #[Autowire(service: 'mcp.server.builder')]
+        private readonly Builder $builder,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('tool', InputArgument::REQUIRED, 'ツール名 (例: search_products)。 一覧は eccube:mcp:tools')
+            ->addOption('args', null, InputOption::VALUE_REQUIRED, 'ツール引数の JSON (例: \'{"keyword":"cube","limit":3}\')', '{}');
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $toolName = (string) $input->getArgument('tool');
+
+        // Builder::build() が discovery ローダを走らせ、 共有 registry に #[McpTool] 群を登録する。
+        // HTTP リクエストを経ない CLI では registry が空のままなので、 引く前に一度 build させる。
+        $this->builder->build();
+
+        $arguments = json_decode((string) $input->getOption('args'), true);
+        // JSON オブジェクト (連想配列) のみ受ける。 非空の JSON 配列 (例 [1,2,3]) は引数名で
+        // 解決できず全パラメータが既定値実行になり黙って誤動作するため弾く ([] は {} と同義で許可)。
+        if (!\is_array($arguments) || (array_is_list($arguments) && [] !== $arguments)) {
+            $io->error('--args は JSON オブジェクトで指定してください (例: \'{"limit":3}\')。');
+
+            return Command::INVALID;
+        }
+
+        try {
+            $reference = $this->registry->getTool($toolName);
+        } catch (ToolNotFoundException) {
+            $available = [];
+            $cursor = null;
+            do {
+                $page = $this->registry->getTools(null, $cursor);
+                foreach ($page->references as $tool) {
+                    $available[] = $tool->name;
+                }
+                $cursor = $page->nextCursor;
+            } while (null !== $cursor);
+
+            $io->error(sprintf('未知のツール: %s', $toolName));
+            $io->writeln('利用可能: '.implode(', ', $available));
+
+            return Command::INVALID;
+        }
+
+        // sdk の ReferenceHandler は arguments['_session'] を無条件参照する (本来はサーバが
+        // リクエスト時に注入する)。 CLI にセッションは無く、 各ツールも session を引数に取らないため
+        // null を置いてキー欠落の warning だけ回避する (RequestContext 経路は isset で誤爆しない)。
+        $arguments['_session'] = null;
+
+        // ツール実行の例外は捕まえず Symfony に委ねる (メッセージ・トレース・非0終了を得るため)。
+        $result = $this->handler->handle($reference, $arguments);
+
+        // JSON_THROW_ON_ERROR: 不正 UTF-8 等でのエンコード失敗を空出力+成功にせず例外で落とす。
+        $output->writeln(json_encode($result, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Eccube/Command/McpToolsCommand.php
+++ b/src/Eccube/Command/McpToolsCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Command;
+
+use Mcp\Capability\RegistryInterface;
+use Mcp\Server\Builder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * 利用可能な MCP ツールの一覧 (名前・説明・入力スキーマ) を JSON で出力する。
+ *
+ * MCP の `tools/list` に相当する。 コンソール AI クライアント (Claude Code 等) が、
+ * コンテキストを食う MCP サーバ接続なしに、 CLI から同じツール群を発見・実行するための入口。
+ * ツール集合は mcp-bundle の Registry を再利用するため、 ツール追加時に本コマンドの変更は不要。
+ */
+#[AsCommand(
+    name: 'eccube:mcp:tools',
+    description: '利用可能な MCP ツールの一覧 (名前・説明・入力スキーマ) を JSON で出力する',
+)]
+final class McpToolsCommand extends Command
+{
+    public function __construct(
+        #[Autowire(service: 'mcp.registry')]
+        private readonly RegistryInterface $registry,
+        #[Autowire(service: 'mcp.server.builder')]
+        private readonly Builder $builder,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this->addOption('names-only', null, InputOption::VALUE_NONE, 'ツール名だけを出力する');
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $namesOnly = (bool) $input->getOption('names-only');
+
+        // Builder::build() が discovery ローダを走らせ、 共有 registry に #[McpTool] 群を登録する。
+        // HTTP リクエストを経ない CLI では registry が空のままなので、 読む前に一度 build させる。
+        $this->builder->build();
+
+        $tools = [];
+        $cursor = null;
+        do {
+            $page = $this->registry->getTools(null, $cursor);
+            foreach ($page->references as $tool) {
+                // getTools() の Page->references は Mcp\Schema\Tool を直接持つ
+                $tools[] = $namesOnly ? $tool->name : [
+                    'name' => $tool->name,
+                    'description' => $tool->description,
+                    'inputSchema' => $tool->inputSchema,
+                ];
+            }
+            $cursor = $page->nextCursor;
+        } while (null !== $cursor);
+
+        // JSON_THROW_ON_ERROR: エンコード失敗を空出力+成功にせず例外で落とす。
+        $output->writeln(json_encode($tools, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Eccube/Tests/Command/McpCommandTest.php
+++ b/tests/Eccube/Tests/Command/McpCommandTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Eccube\Tests\Command;
+
+use Eccube\Command\McpCallCommand;
+use Eccube\Command\McpToolsCommand;
+use Eccube\Tests\EccubeTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * MCP の CLI ディスパッチャ (`eccube:mcp:tools` / `eccube:mcp:call`) の結合テスト。
+ *
+ * ツール集合・射影は mcp-bundle の Registry と Api44 の allow_list に依存するため、
+ * Api44 導入済みの mcp ジョブで実走する。
+ */
+#[Group('mcp')]
+final class McpCommandTest extends EccubeTestCase
+{
+    public function testToolsListsDiscoveredTools(): void
+    {
+        $command = static::getContainer()->get(McpToolsCommand::class);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+
+        $tools = json_decode($tester->getDisplay(), true);
+        $this->assertIsArray($tools);
+        $names = array_column($tools, 'name');
+        $this->assertContains('search_products', $names);
+        $this->assertContains('get_product', $names);
+
+        // 各要素が tools/list と同じ name/description/inputSchema を持つ
+        foreach ($tools as $tool) {
+            $this->assertArrayHasKey('name', $tool);
+            $this->assertArrayHasKey('description', $tool);
+            $this->assertArrayHasKey('inputSchema', $tool);
+        }
+    }
+
+    public function testToolsNamesOnly(): void
+    {
+        $command = static::getContainer()->get(McpToolsCommand::class);
+        $tester = new CommandTester($command);
+        $tester->execute(['--names-only' => true]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+
+        $names = json_decode($tester->getDisplay(), true);
+        $this->assertIsArray($names);
+        $this->assertContains('search_products', $names);
+    }
+
+    public function testCallReturnsSummaryShape(): void
+    {
+        $product = $this->createProduct('MCPCLI Test Product');
+
+        $command = static::getContainer()->get(McpCallCommand::class);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'tool' => 'search_products',
+            '--args' => json_encode(['keyword' => 'MCPCLI Test Product', 'limit' => 5]),
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+
+        $result = json_decode($tester->getDisplay(), true);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('items', $result);
+
+        $item = null;
+        foreach ($result['items'] as $candidate) {
+            if (($candidate['id'] ?? null) === $product->getId()) {
+                $item = $candidate;
+                break;
+            }
+        }
+        $this->assertNotNull($item, '作成した商品が検索結果に含まれること');
+
+        // search_* はサマリ射影: price/stock の集約はあるが、 詳細フィールドは含まない
+        $this->assertArrayHasKey('price', $item);
+        $this->assertArrayHasKey('stock', $item);
+        $this->assertArrayNotHasKey('description_detail', $item);
+    }
+
+    public function testCallUnknownToolFails(): void
+    {
+        $command = static::getContainer()->get(McpCallCommand::class);
+        $tester = new CommandTester($command);
+        $tester->execute(['tool' => 'no_such_tool']);
+
+        $this->assertSame(Command::INVALID, $tester->getStatusCode());
+        $this->assertStringContainsString('search_products', $tester->getDisplay());
+    }
+
+    public function testCallInvalidJsonFails(): void
+    {
+        $command = static::getContainer()->get(McpCallCommand::class);
+        $tester = new CommandTester($command);
+        $tester->execute(['tool' => 'search_products', '--args' => 'not-json']);
+
+        $this->assertSame(Command::INVALID, $tester->getStatusCode());
+    }
+
+    public function testCallJsonArrayArgsFails(): void
+    {
+        // 非空の JSON 配列は引数名で解決できず全既定値実行になるため INVALID で弾く
+        $command = static::getContainer()->get(McpCallCommand::class);
+        $tester = new CommandTester($command);
+        $tester->execute(['tool' => 'search_products', '--args' => '[1,2,3]']);
+
+        $this->assertSame(Command::INVALID, $tester->getStatusCode());
+    }
+}


### PR DESCRIPTION
## 概要

MCP サーバでできる操作を `bin/console` からも同じように実行できるディスパッチャを追加します。`playwright-mcp` に対する `playwright-cli` と同じ位置づけです。

コンソールで動く AI クライアント（Claude Code 等）は、MCP サーバに接続するとコンテキスト消費が大きくなります。同じ操作を CLI から叩ければ、接続オーバーヘッドなしに同等のことができます。ローカル実行＝サーバ / DB にアクセスできる人と同等の権限なので、**認証トークンは不要**です。

## 追加コマンド

| コマンド | MCP 相当 | 内容 |
|----------|----------|------|
| `eccube:mcp:tools` | `tools/list` | 登録ツールの name / description / inputSchema を JSON 出力（`--names-only` で名前のみ） |
| `eccube:mcp:call <tool> --args=<JSON>` | `tools/call` | ツールを実行し結果を生 JSON で出力 |

```console
$ bin/console eccube:mcp:call search_products --args='{"keyword":"cube","limit":3}'
{ "total": 1, "limit": 3, "offset": 0, "items": [ { "id": 1, "name": "彩のジェラートCUBE", "price": {"min":"5000","max":"110000"}, ... } ] }
```

## 設計

- **ツール集合は mcp-bundle の Registry を再利用**。ツールを追加しても CLI 側は変更不要。
- **トークン / scope 強制は通さない**。ローカル実行前提のため、scope 強制なしの inner ReferenceHandler を使う（HTTP の OAuth Bearer + scope とは別の「ローカル信頼」で運用）。
- CLI は HTTP リクエストを経ないため registry が空になる。実行前に `Builder::build()` で discovery ローダを走らせてツールを登録する。
- 出力は各ツールの生データ（search_* はサマリ、get_* は詳細）。AI クライアント / スクリプトがそのまま食える形。

## テスト

`tests/Eccube/Tests/Command/McpCommandTest.php`（`#[Group('mcp')]`、`CommandTester`）で以下を検証:
- tools が 11 ツールを name/description/inputSchema で返す
- call が実データでサマリ形を返す
- 未知ツール / 不正 JSON / 非空 JSON 配列を非 0 終了で弾く

php-cs-fixer / phpstan (level 6) / rector すべて通過。

## 依存・base について

この PR は MCP サーバ本体（EC-CUBE/ec-cube#6832）のツール群を再利用するため、**base を `feature/poc-mcp` に設定したスタック PR** です。diff は CLI 追加分のみになります。#6832 が merge されたら base を `4.4` に切り替えて本体への PR に昇格できます。
